### PR TITLE
Refactor bindings

### DIFF
--- a/FractalAudioGen/Form1.Designer.cs
+++ b/FractalAudioGen/Form1.Designer.cs
@@ -12,114 +12,121 @@
         private System.Windows.Forms.TrackBar trackBinauralOffset;
         private System.Windows.Forms.ComboBox cmbWaveType;
 
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
         private void InitializeComponent()
         {
-            this.btnPlay = new System.Windows.Forms.Button();
-            this.btnStop = new System.Windows.Forms.Button();
-            this.lblFrequency = new System.Windows.Forms.Label();
-            this.cmbHealingFrequencies = new System.Windows.Forms.ComboBox();
-            this.lblBinauralOffset = new System.Windows.Forms.Label();
-            this.trackBinauralOffset = new System.Windows.Forms.TrackBar();
-            this.cmbWaveType = new System.Windows.Forms.ComboBox();
+            btnPlay = new System.Windows.Forms.Button();
 
-            this.SuspendLayout();
 
-            // 
-            // Form Properties
-            // 
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(500, 300); // Adjust form size
-            this.Text = "Healing Frequency Generator";
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.MaximizeBox = false;
 
+            btnStop = new System.Windows.Forms.Button();
+            lblFrequency = new System.Windows.Forms.Label();
+            cmbHealingFrequencies = new System.Windows.Forms.ComboBox();
+            lblBinauralOffset = new System.Windows.Forms.Label();
+            trackBinauralOffset = new System.Windows.Forms.TrackBar();
+            cmbWaveType = new System.Windows.Forms.ComboBox();
+            waveType = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)trackBinauralOffset).BeginInit();
+            SuspendLayout();
             // 
             // btnPlay
             // 
-            this.btnPlay.Text = "Play";
-            this.btnPlay.Location = new System.Drawing.Point(20, 20);
-            this.btnPlay.Size = new System.Drawing.Size(80, 30);
-            this.btnPlay.Click += new System.EventHandler(this.BtnPlay_Click);
-            this.Controls.Add(this.btnPlay);
-
+            btnPlay.Location = new System.Drawing.Point(20, 20);
+            btnPlay.Name = "btnPlay";
+            btnPlay.Size = new System.Drawing.Size(80, 30);
+            btnPlay.TabIndex = 0;
+            btnPlay.Text = "Play";
+            btnPlay.Click += BtnPlay_Click;
             // 
             // btnStop
             // 
-            this.btnStop.Text = "Stop";
-            this.btnStop.Location = new System.Drawing.Point(110, 20);
-            this.btnStop.Size = new System.Drawing.Size(80, 30);
-            this.btnStop.Click += new System.EventHandler(this.BtnStop_Click);
-            this.Controls.Add(this.btnStop);
-
+            btnStop.Location = new System.Drawing.Point(110, 20);
+            btnStop.Name = "btnStop";
+            btnStop.Size = new System.Drawing.Size(80, 30);
+            btnStop.TabIndex = 1;
+            btnStop.Text = "Stop";
+            btnStop.Click += BtnStop_Click;
             // 
             // lblFrequency
             // 
-            this.lblFrequency.Text = "Frequency:";
-            this.lblFrequency.Location = new System.Drawing.Point(20, 70);
-            this.lblFrequency.AutoSize = true;
-            this.Controls.Add(this.lblFrequency);
-
+            lblFrequency.AutoSize = true;
+            lblFrequency.Location = new System.Drawing.Point(20, 70);
+            lblFrequency.Name = "lblFrequency";
+            lblFrequency.Size = new System.Drawing.Size(79, 20);
+            lblFrequency.TabIndex = 2;
+            lblFrequency.Text = "Frequency:";
             // 
             // cmbHealingFrequencies
             // 
-            this.cmbHealingFrequencies.Location = new System.Drawing.Point(120, 65);
-            this.cmbHealingFrequencies.Size = new System.Drawing.Size(200, 25);
-            this.cmbHealingFrequencies.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbHealingFrequencies.Items.AddRange(new string[] {
-                "174 Hz - Pain Relief",
-                "285 Hz - Tissue Healing",
-                "396 Hz - Fear Reduction",
-                "417 Hz - Negative Energy",
-                "432 Hz - Natural Harmony",
-                "528 Hz - DNA Repair",
-                "639 Hz - Love & Connection",
-                "741 Hz - Detox & Immunity",
-                "852 Hz - Intuition Boost",
-                "963 Hz - Pineal Gland"
-            });
-            this.cmbHealingFrequencies.SelectedIndex = 5; // Default to 528 Hz
-            this.cmbHealingFrequencies.SelectedIndexChanged += new System.EventHandler(this.CmbHealingFrequencies_SelectedIndexChanged);
-            this.Controls.Add(this.cmbHealingFrequencies);
-
+            cmbHealingFrequencies.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            cmbHealingFrequencies.Items.AddRange(new object[] { "174 Hz - Pain Relief", "285 Hz - Tissue Healing", "396 Hz - Fear Reduction", "417 Hz - Negative Energy", "432 Hz - Natural Harmony", "528 Hz - DNA Repair", "639 Hz - Love & Connection", "741 Hz - Detox & Immunity", "852 Hz - Intuition Boost", "963 Hz - Pineal Gland" });
+            cmbHealingFrequencies.Location = new System.Drawing.Point(120, 65);
+            cmbHealingFrequencies.Name = "cmbHealingFrequencies";
+            cmbHealingFrequencies.Size = new System.Drawing.Size(200, 28);
+            cmbHealingFrequencies.TabIndex = 3;
+            cmbHealingFrequencies.SelectedIndexChanged += CmbHealingFrequencies_SelectedIndexChanged;
             // 
             // lblBinauralOffset
             // 
-            this.lblBinauralOffset.Text = "Binaural Offset: 0 Hz";
-            this.lblBinauralOffset.Location = new System.Drawing.Point(20, 120);
-            this.lblBinauralOffset.AutoSize = true;
-            this.Controls.Add(this.lblBinauralOffset);
-
+            lblBinauralOffset.AutoSize = true;
+            lblBinauralOffset.Location = new System.Drawing.Point(20, 120);
+            lblBinauralOffset.Name = "lblBinauralOffset";
+            lblBinauralOffset.Size = new System.Drawing.Size(144, 20);
+            lblBinauralOffset.TabIndex = 4;
+            lblBinauralOffset.Text = "Binaural Offset: 0 Hz";
             // 
             // trackBinauralOffset
             // 
-            this.trackBinauralOffset.Location = new System.Drawing.Point(20, 140);
-            this.trackBinauralOffset.Size = new System.Drawing.Size(300, 40);
-            this.trackBinauralOffset.Minimum = 0;
-            this.trackBinauralOffset.Maximum = 20;
-            this.trackBinauralOffset.TickFrequency = 1;
-            this.trackBinauralOffset.ValueChanged += new System.EventHandler(this.TrackBinauralOffset_Scroll);
-            this.Controls.Add(this.trackBinauralOffset);
-
+            trackBinauralOffset.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right));
+            trackBinauralOffset.Location = new System.Drawing.Point(20, 140);
+            trackBinauralOffset.Maximum = 20;
+            trackBinauralOffset.Name = "trackBinauralOffset";
+            trackBinauralOffset.Size = new System.Drawing.Size(339, 56);
+            trackBinauralOffset.TabIndex = 5;
+            trackBinauralOffset.ValueChanged += TrackBinauralOffset_Scroll;
             // 
             // cmbWaveType
             // 
-            this.cmbWaveType.Location = new System.Drawing.Point(20, 190);
-            this.cmbWaveType.Size = new System.Drawing.Size(200, 25);
-            this.cmbWaveType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbWaveType.Items.AddRange(new string[] {
-                "Sine",
-                "Square",
-                "Triangle",
-                "Sawtooth"
-            });
-            this.cmbWaveType.SelectedIndex = 0; // Default to Sine
-            this.cmbWaveType.SelectedIndexChanged += new System.EventHandler(this.CmbWaveType_SelectedIndexChanged);
-            this.Controls.Add(this.cmbWaveType);
-
+            cmbWaveType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            cmbWaveType.Location = new System.Drawing.Point(121, 201);
+            cmbWaveType.Name = "cmbWaveType";
+            cmbWaveType.Size = new System.Drawing.Size(200, 28);
+            cmbWaveType.TabIndex = 6;
+            cmbWaveType.SelectedIndexChanged += CmbWaveType_SelectedIndexChanged;
             // 
-            // Finalize Form
+            // waveType
             // 
-            this.ResumeLayout(false);
+            waveType.Location = new System.Drawing.Point(17, 198);
+            waveType.Name = "waveType";
+            waveType.Size = new System.Drawing.Size(98, 32);
+            waveType.TabIndex = 7;
+            waveType.Text = "Wave Type:";
+            waveType.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // Form1
+            // 
+            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(371, 257);
+            Controls.Add(waveType);
+            Controls.Add(btnPlay);
+            Controls.Add(btnStop);
+            Controls.Add(lblFrequency);
+            Controls.Add(cmbHealingFrequencies);
+            Controls.Add(lblBinauralOffset);
+            Controls.Add(trackBinauralOffset);
+            Controls.Add(cmbWaveType);
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            MaximizeBox = false;
+            Text = "Healing Frequency Generator";
+            ((System.ComponentModel.ISupportInitialize)trackBinauralOffset).EndInit();
+            ResumeLayout(false);
+            PerformLayout();
         }
+
+        private System.Windows.Forms.Label waveType;
     }
 }

--- a/FractalAudioGen/Form1.Designer.cs
+++ b/FractalAudioGen/Form1.Designer.cs
@@ -11,6 +11,7 @@
         private System.Windows.Forms.Label lblBinauralOffset;
         private System.Windows.Forms.TrackBar trackBinauralOffset;
         private System.Windows.Forms.ComboBox cmbWaveType;
+        private System.Windows.Forms.Label lblWaveType;
 
         /// <summary>
         /// Required method for Designer support - do not modify
@@ -19,48 +20,45 @@
         private void InitializeComponent()
         {
             btnPlay = new System.Windows.Forms.Button();
-
-
-
             btnStop = new System.Windows.Forms.Button();
             lblFrequency = new System.Windows.Forms.Label();
             cmbHealingFrequencies = new System.Windows.Forms.ComboBox();
             lblBinauralOffset = new System.Windows.Forms.Label();
             trackBinauralOffset = new System.Windows.Forms.TrackBar();
             cmbWaveType = new System.Windows.Forms.ComboBox();
-            waveType = new System.Windows.Forms.Label();
+            lblWaveType = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)trackBinauralOffset).BeginInit();
             SuspendLayout();
-            // 
+            //
             // btnPlay
-            // 
+            //
             btnPlay.Location = new System.Drawing.Point(20, 20);
             btnPlay.Name = "btnPlay";
             btnPlay.Size = new System.Drawing.Size(80, 30);
             btnPlay.TabIndex = 0;
             btnPlay.Text = "Play";
             btnPlay.Click += BtnPlay_Click;
-            // 
+            //
             // btnStop
-            // 
+            //
             btnStop.Location = new System.Drawing.Point(110, 20);
             btnStop.Name = "btnStop";
             btnStop.Size = new System.Drawing.Size(80, 30);
             btnStop.TabIndex = 1;
             btnStop.Text = "Stop";
             btnStop.Click += BtnStop_Click;
-            // 
+            //
             // lblFrequency
-            // 
+            //
             lblFrequency.AutoSize = true;
             lblFrequency.Location = new System.Drawing.Point(20, 70);
             lblFrequency.Name = "lblFrequency";
             lblFrequency.Size = new System.Drawing.Size(79, 20);
             lblFrequency.TabIndex = 2;
             lblFrequency.Text = "Frequency:";
-            // 
+            //
             // cmbHealingFrequencies
-            // 
+            //
             cmbHealingFrequencies.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             cmbHealingFrequencies.Items.AddRange(new object[] { "174 Hz - Pain Relief", "285 Hz - Tissue Healing", "396 Hz - Fear Reduction", "417 Hz - Negative Energy", "432 Hz - Natural Harmony", "528 Hz - DNA Repair", "639 Hz - Love & Connection", "741 Hz - Detox & Immunity", "852 Hz - Intuition Boost", "963 Hz - Pineal Gland" });
             cmbHealingFrequencies.Location = new System.Drawing.Point(120, 65);
@@ -68,18 +66,18 @@
             cmbHealingFrequencies.Size = new System.Drawing.Size(200, 28);
             cmbHealingFrequencies.TabIndex = 3;
             cmbHealingFrequencies.SelectedIndexChanged += CmbHealingFrequencies_SelectedIndexChanged;
-            // 
+            //
             // lblBinauralOffset
-            // 
+            //
             lblBinauralOffset.AutoSize = true;
             lblBinauralOffset.Location = new System.Drawing.Point(20, 120);
             lblBinauralOffset.Name = "lblBinauralOffset";
             lblBinauralOffset.Size = new System.Drawing.Size(144, 20);
             lblBinauralOffset.TabIndex = 4;
             lblBinauralOffset.Text = "Binaural Offset: 0 Hz";
-            // 
+            //
             // trackBinauralOffset
-            // 
+            //
             trackBinauralOffset.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right));
             trackBinauralOffset.Location = new System.Drawing.Point(20, 140);
             trackBinauralOffset.Maximum = 20;
@@ -87,37 +85,37 @@
             trackBinauralOffset.Size = new System.Drawing.Size(339, 56);
             trackBinauralOffset.TabIndex = 5;
             trackBinauralOffset.ValueChanged += TrackBinauralOffset_Scroll;
-            // 
+            //
             // cmbWaveType
-            // 
+            //
             cmbWaveType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             cmbWaveType.Location = new System.Drawing.Point(121, 201);
             cmbWaveType.Name = "cmbWaveType";
             cmbWaveType.Size = new System.Drawing.Size(200, 28);
             cmbWaveType.TabIndex = 6;
             cmbWaveType.SelectedIndexChanged += CmbWaveType_SelectedIndexChanged;
-            // 
-            // waveType
-            // 
-            waveType.Location = new System.Drawing.Point(17, 198);
-            waveType.Name = "waveType";
-            waveType.Size = new System.Drawing.Size(98, 32);
-            waveType.TabIndex = 7;
-            waveType.Text = "Wave Type:";
-            waveType.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
+            //
+            // lblWaveType
+            //
+            lblWaveType.Location = new System.Drawing.Point(17, 198);
+            lblWaveType.Name = "lblWaveType";
+            lblWaveType.Size = new System.Drawing.Size(98, 32);
+            lblWaveType.TabIndex = 7;
+            lblWaveType.Text = "Wave Type:";
+            lblWaveType.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            //
             // Form1
-            // 
+            //
             AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             ClientSize = new System.Drawing.Size(371, 257);
-            Controls.Add(waveType);
             Controls.Add(btnPlay);
             Controls.Add(btnStop);
             Controls.Add(lblFrequency);
             Controls.Add(cmbHealingFrequencies);
             Controls.Add(lblBinauralOffset);
             Controls.Add(trackBinauralOffset);
+            Controls.Add(lblWaveType);
             Controls.Add(cmbWaveType);
             FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             MaximizeBox = false;
@@ -126,7 +124,5 @@
             ResumeLayout(false);
             PerformLayout();
         }
-
-        private System.Windows.Forms.Label waveType;
     }
 }

--- a/FractalAudioGen/Form1.cs
+++ b/FractalAudioGen/Form1.cs
@@ -9,6 +9,20 @@ namespace FractalAudioGen
         private readonly WaveOutEvent waveOut;
         private readonly FractalWaveProvider waveProvider;
 
+        private readonly IReadOnlyDictionary<int, string> supportedFrequencies = new Dictionary<int, string>
+        {
+            { 174, "Pain Relief" },
+            { 285, "Tissue Healing" },
+            { 396, "Fear Reduction" },
+            { 417, "Negative Energy" },
+            { 432, "Natural Harmony" },
+            { 528, "DNA Repair" },
+            { 639, "Love & Connection" },
+            { 741, "Detox & Immunity" },
+            { 852, "Intuition Boost" },
+            { 963, "Pineal Gland" },
+        };
+
         public Form1()
         {
             // Perform app init
@@ -20,8 +34,27 @@ namespace FractalAudioGen
             InitializeComponent();
 
             // Bind controls
-            cmbHealingFrequencies.SelectedIndex = 0;
+            cmbHealingFrequencies.DataSource = new BindingSource(supportedFrequencies, null);
+            cmbHealingFrequencies.DisplayMember = "Value";
+            cmbHealingFrequencies.ValueMember = "Key";
+            cmbHealingFrequencies.FormattingEnabled = true;
+            // Format list entries by listing both Hz and intent
+            cmbHealingFrequencies.Format += (_, args) =>
+            {
+                var listItem = (KeyValuePair<int, string>)args.ListItem!;
+                args.Value = $"{listItem.Key} Hz - {listItem.Value}";
+            };
+
+            // cmbHealingFrequencies.FormattingEnabled = true;
+            // cmbHealingFrequencies.FormatString = "{0} Hz - {1}";
+
+            // Set our default to DNA Repair
+            cmbHealingFrequencies.SelectedIndex = 5;
+
             cmbWaveType.DataSource = Enum.GetValues<FractalWaveType>();
+
+            // Stop is disabled by default, nothing is playing yet
+            btnStop.Enabled = false;
         }
 
         private void BtnPlay_Click(object sender, EventArgs e)
@@ -29,6 +62,8 @@ namespace FractalAudioGen
             if (waveOut.PlaybackState != PlaybackState.Playing)
             {
                 waveOut.Play();
+                btnPlay.Enabled = false;
+                btnStop.Enabled = true;
             }
         }
 
@@ -37,24 +72,24 @@ namespace FractalAudioGen
             if (waveOut.PlaybackState == PlaybackState.Playing)
             {
                 waveOut.Stop();
+                btnPlay.Enabled = true;
+                btnStop.Enabled = false;
             }
         }
 
         private void CmbHealingFrequencies_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (cmbHealingFrequencies.SelectedItem is string selection)
-            {
-                UpdateFrequency(selection);
-            }
+            // When the control is first initialized, bindings are not set up yet - allow early term
+            if (cmbHealingFrequencies.SelectedValue is not int selectedFrequency)
+                return;
+
+            waveProvider.Frequency = selectedFrequency;
         }
 
         private void TrackBinauralOffset_Scroll(object sender, EventArgs e)
         {
-            if (trackBinauralOffset != null && lblBinauralOffset != null)
-            {
-                waveProvider.BinauralOffset = trackBinauralOffset.Value;
-                lblBinauralOffset.Text = $"Binaural Offset: {trackBinauralOffset.Value} Hz";
-            }
+            waveProvider.BinauralOffset = trackBinauralOffset.Value;
+            lblBinauralOffset.Text = $"Binaural Offset: {trackBinauralOffset.Value} Hz";
         }
 
         private void CmbWaveType_SelectedIndexChanged(object sender, EventArgs e)
@@ -62,48 +97,6 @@ namespace FractalAudioGen
             if (cmbWaveType.SelectedItem is FractalWaveType waveType)
             {
                 waveProvider.WaveType = waveType;
-            }
-        }
-
-        private void UpdateFrequency(string selection)
-        {
-            if (string.IsNullOrEmpty(selection)) return;
-
-            switch (selection)
-            {
-                case "174 Hz - Pain Relief":
-                    waveProvider.Frequency = 174;
-                    break;
-                case "285 Hz - Tissue Healing":
-                    waveProvider.Frequency = 285;
-                    break;
-                case "396 Hz - Fear Reduction":
-                    waveProvider.Frequency = 396;
-                    break;
-                case "417 Hz - Negative Energy":
-                    waveProvider.Frequency = 417;
-                    break;
-                case "432 Hz - Natural Harmony":
-                    waveProvider.Frequency = 432;
-                    break;
-                case "528 Hz - DNA Repair":
-                    waveProvider.Frequency = 528;
-                    break;
-                case "639 Hz - Love & Connection":
-                    waveProvider.Frequency = 639;
-                    break;
-                case "741 Hz - Detox & Immunity":
-                    waveProvider.Frequency = 741;
-                    break;
-                case "852 Hz - Intuition Boost":
-                    waveProvider.Frequency = 852;
-                    break;
-                case "963 Hz - Pineal Gland":
-                    waveProvider.Frequency = 963;
-                    break;
-                default:
-                    waveProvider.Frequency = 528; // Default to 528 Hz
-                    break;
             }
         }
     }

--- a/FractalAudioGen/Form1.cs
+++ b/FractalAudioGen/Form1.cs
@@ -6,24 +6,27 @@ namespace FractalAudioGen
 {
     public partial class Form1 : Form
     {
-        private WaveOutEvent waveOut;
-        private FractalWaveProvider waveProvider;
+        private readonly WaveOutEvent waveOut;
+        private readonly FractalWaveProvider waveProvider;
 
         public Form1()
         {
-            InitializeComponent();
+            // Perform app init
             waveProvider = new FractalWaveProvider();
             waveOut = new WaveOutEvent();
             waveOut.Init(waveProvider);
 
-            // Prevent null reference issues
+            // Start UI
+            InitializeComponent();
+
+            // Bind controls
             cmbHealingFrequencies.SelectedIndex = 0;
-            cmbWaveType.SelectedIndex = 0;
+            cmbWaveType.DataSource = Enum.GetValues<FractalWaveType>();
         }
 
         private void BtnPlay_Click(object sender, EventArgs e)
         {
-            if (waveOut != null && waveOut.PlaybackState != PlaybackState.Playing)
+            if (waveOut.PlaybackState != PlaybackState.Playing)
             {
                 waveOut.Play();
             }
@@ -31,7 +34,7 @@ namespace FractalAudioGen
 
         private void BtnStop_Click(object sender, EventArgs e)
         {
-            if (waveOut != null && waveOut.PlaybackState == PlaybackState.Playing)
+            if (waveOut.PlaybackState == PlaybackState.Playing)
             {
                 waveOut.Stop();
             }
@@ -56,7 +59,7 @@ namespace FractalAudioGen
 
         private void CmbWaveType_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (cmbWaveType.SelectedItem is string waveType)
+            if (cmbWaveType.SelectedItem is FractalWaveType waveType)
             {
                 waveProvider.WaveType = waveType;
             }

--- a/FractalAudioGen/FractalWaveProvider.cs
+++ b/FractalAudioGen/FractalWaveProvider.cs
@@ -5,22 +5,23 @@ namespace FractalAudioGen
 {
     public class FractalWaveProvider : WaveProvider32
     {
-        private double phaseLeft = 0;
-        private double phaseRight = 0;
-        private readonly int sampleRate = 44100;
+        private const int SAMPLE_RATE = 44100;
+
         public double Frequency { get; set; } = 528; // Default to 528 Hz
         public double BinauralOffset { get; set; } = 4; // Default binaural offset
-        public string WaveType { get; set; } = "Sine";
+        public FractalWaveType WaveType { get; set; } = FractalWaveType.Sine;
 
         public override int Read(float[] buffer, int offset, int count)
         {
+            double phaseLeft = 0, phaseRight = 0;
+
             for (int i = 0; i < count; i += 2)
             {
-                buffer[i + offset] = GenerateWaveSample(phaseLeft); // Left ear
-                buffer[i + offset + 1] = GenerateWaveSample(phaseRight); // Right ear
+                buffer[offset + i] = GenerateWaveSample(phaseLeft); // Left ear
+                buffer[offset + i + 1] = GenerateWaveSample(phaseRight); // Right ear
 
-                phaseLeft += 2 * Math.PI * Frequency / sampleRate;
-                phaseRight += 2 * Math.PI * (Frequency + BinauralOffset) / sampleRate;
+                phaseLeft += 2 * Math.PI * Frequency / SAMPLE_RATE;
+                phaseRight += 2 * Math.PI * (Frequency + BinauralOffset) / SAMPLE_RATE;
 
                 if (phaseLeft > 2 * Math.PI) phaseLeft -= 2 * Math.PI;
                 if (phaseRight > 2 * Math.PI) phaseRight -= 2 * Math.PI;
@@ -32,11 +33,11 @@ namespace FractalAudioGen
         {
             return WaveType switch
             {
-                "Sine" => (float)Math.Sin(phase),
-                "Square" => (float)(Math.Sign(Math.Sin(phase))),
-                "Sawtooth" => (float)((2.0 * (phase / (2 * Math.PI))) - 1.0),
-                "Triangle" => (float)(2.0 * Math.Abs(2.0 * (phase / (2 * Math.PI)) - 1.0) - 1.0),
-                _ => (float)Math.Sin(phase)
+                FractalWaveType.Sine => (float)Math.Sin(phase),
+                FractalWaveType.Square => Math.Sign(Math.Sin(phase)),
+                FractalWaveType.Sawtooth => (float)(2.0 * (phase / (2 * Math.PI)) - 1.0),
+                FractalWaveType.Triangle => (float)(2.0 * Math.Abs(2.0 * (phase / (2 * Math.PI)) - 1.0) - 1.0),
+                _ => throw new NotSupportedException(WaveType.ToString())
             };
         }
     }

--- a/FractalAudioGen/FractalWaveType.cs
+++ b/FractalAudioGen/FractalWaveType.cs
@@ -1,0 +1,9 @@
+namespace FractalAudioGen;
+
+public enum FractalWaveType
+{
+    Sine,
+    Square,
+    Sawtooth,
+    Triangle
+}


### PR DESCRIPTION
Bindings are useful for keeping core code type aware, reducing required casting. This adds bindings for the frequency and wave type combos, making it easier to change and modify the data sources and have changes reflected in the UI. Also opens the door for runtime additions of frequency types. 